### PR TITLE
Fix for @@masterselect-jsonvalue-vocabulary not outputting labels.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 0.4.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix for @@masterselect-jsonvalue-vocabulary not outputting labels.
+  [mitakas]
 
 
 0.4.8 (2015-08-06)

--- a/src/Products/MasterSelectWidget/browser.py
+++ b/src/Products/MasterSelectWidget/browser.py
@@ -128,7 +128,7 @@ class JSONValuesForVocabularyChange(JSONValuesForAction):
         actualValue = field.getAccessor(self.context)()
         if not isinstance(actualValue, (list, tuple)):
             actualValue = [actualValue]
-        vocabulary = DisplayList(zip(vocabulary.keys(), vocabulary.items()))
+        vocabulary = DisplayList(zip(vocabulary.keys(), vocabulary.values()))
 
         json_voc = json.dumps([
             dict(

--- a/src/Products/MasterSelectWidget/browser.py
+++ b/src/Products/MasterSelectWidget/browser.py
@@ -128,7 +128,7 @@ class JSONValuesForVocabularyChange(JSONValuesForAction):
         actualValue = field.getAccessor(self.context)()
         if not isinstance(actualValue, (list, tuple)):
             actualValue = [actualValue]
-        vocabulary = DisplayList(zip(vocabulary, vocabulary))
+        vocabulary = DisplayList(zip(vocabulary.keys(), vocabulary.items()))
 
         json_voc = json.dumps([
             dict(


### PR DESCRIPTION
@@masterselect-jsonvalue-vocabulary returns 

``` json
[{"selected": "", "value": "key1", "label": "key1"}]
```

when it should be returning

``` json
[{"selected": "", "value": "key1", "label": "value1"}]
```
